### PR TITLE
Improve `roundCrop` feature

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
         with:
-          node-version: '12'
+          node-version: '14'
 
       - uses: actions/cache@v2
         with:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
         with:
-          node-version: '12'
+          node-version: '14'
 
       - uses: actions/cache@v2
         with:

--- a/source/image-handler/image-handler.js
+++ b/source/image-handler/image-handler.js
@@ -193,7 +193,9 @@ class ImageHandler {
         if (options) {
           const ellipse = Buffer.from(`<svg viewBox="0 0 ${width} ${height}"> <ellipse cx="${leftOffset}" cy="${topOffset}" rx="${radiusX}" ry="${radiusY}" /></svg>`);
           const params = [{input: ellipse, blend: 'dest-in'}];
-          let data = await image.composite(params).toBuffer();
+          let data = await image.composite(params)
+            .png() // transparent background instead of black background
+            .toBuffer();
           image = sharp(data).withMetadata().trim();
         }
 

--- a/source/image-handler/image-request.js
+++ b/source/image-handler/image-request.js
@@ -40,7 +40,8 @@ class ImageRequest {
     /* Decide the output format of the image.
      * 1) If the format is provided, the output format is the provided format.
      * 2) If headers contain "Accept: image/webp", the output format is webp.
-     * 3) Use the default image format for the rest of cases.
+     * 3) If headers contain "Accept: image/avif", the output format is webp.
+     * 4) Use the default image format for the rest of cases.
      */
     if (this.ContentType !== 'image/svg+xml' || this.edits.toFormat || this.outputFormat) {
       let outputFormat = this.getOutputFormat(event);
@@ -262,7 +263,7 @@ class ImageRequest {
       path = path
         .replace(/\/\d+x\d+:\d+x\d+\//g, "/")
         .replace(/\/(\d+|__WIDTH__)x\d+\//g, "/")
-        .replace(/\/(filters|roundCrop):[^\/]+/g, "/")
+        .replace(/\/filters:[^\/]+/g, "/")
         .replace(/\/fit-in\//g, "/")
         .replace(/^\/+/, "")
         .replace(/\/+/g, "/");

--- a/source/image-handler/package.json
+++ b/source/image-handler/package.json
@@ -8,7 +8,7 @@
   "dependencies": {
     "color": "3.1.3",
     "color-name": "1.1.4",
-    "sharp": "0.29.2"
+    "sharp": "0.31.1"
   },
   "devDependencies": {
     "jest": "^26.4.2",

--- a/source/image-handler/test/image-handler.spec.js
+++ b/source/image-handler/test/image-handler.spec.js
@@ -578,7 +578,6 @@ describe('applyEdits()', () => {
 
       const edits = {
         roundCrop: true
-
       };
 
       // Act
@@ -640,7 +639,7 @@ describe('getOverlayImage()', () => {
       const result = await imageHandler.getOverlayImage('validBucket', 'validKey', '100', '100', '20', metadata);
       // Assert
       expect(mockAws.getObject).toHaveBeenCalledWith({Bucket: 'validBucket', Key: 'validKey'});
-      expect(result).toEqual(Buffer.from('iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAACXBIWXMAAAsTAAALEwEAmpwYAAAADUlEQVQImWP4z8CQCgAEZgFll19D6QAAAABJRU5ErkJggg==', 'base64'));
+      expect(result).toEqual(Buffer.from('iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAACXBIWXMAAAsTAAALEwEAmpwYAAAADUlEQVR4nGP4z8CQCgAEZgFltQhIfQAAAABJRU5ErkJggg==', 'base64'));
     });
   });
   describe('002/imageDoesNotExist', () => {

--- a/source/image-handler/test/image-request.spec.js
+++ b/source/image-handler/test/image-request.spec.js
@@ -729,7 +729,7 @@ describe('parseImageEdits()', function () {
     it('Should pass when a thumbor image request is provided and populate the ImageRequest object with the proper values for roundCrop', async function () {
       // Arrange
       const event = {
-        path: "/filters:round(1x2:3x4)/test-image-001.jpg"
+        path: "/filters:roundCrop(1x2:3x4)/test-image-001.jpg"
       }
       process.env = {
         SOURCE_BUCKETS: "allowedBucket001, allowedBucket002"

--- a/source/image-handler/test/thumbor-mapping.spec.js
+++ b/source/image-handler/test/thumbor-mapping.spec.js
@@ -964,4 +964,30 @@ describe('mapFilter()', function() {
             expect(thumborMapping).toEqual(expectedResult);
         });
     });
+    describe('037/simple_round', function() {
+        it('Should pass if undefined is returned for an unsupported filter', function() {
+            // Arrange
+            const edit = 'filters:roundCrop()';
+            const filetype = 'jpg';
+            // Act
+            const thumborMapping = new ThumborMapping();
+            thumborMapping.mapFilter(edit, filetype);
+            // Assert
+            const expectedResult = {edits: {roundCrop: {}}};
+            expect(thumborMapping).toEqual(expectedResult);
+        });
+    });
+    describe('038/simple_round', function() {
+        it('Should pass if undefined is returned for an unsupported filter', function() {
+            // Arrange
+            const edit = 'filters:roundCrop(true)';
+            const filetype = 'jpg';
+            // Act
+            const thumborMapping = new ThumborMapping();
+            thumborMapping.mapFilter(edit, filetype);
+            // Assert
+            const expectedResult = {edits: {roundCrop: {}}};
+            expect(thumborMapping).toEqual(expectedResult);
+        });
+    });
 })

--- a/source/image-handler/thumbor-mapping.js
+++ b/source/image-handler/thumbor-mapping.js
@@ -67,6 +67,11 @@ class ThumborMapping {
       }
     }
 
+    // Parse roundCrop
+    if (this.path.includes('/roundCrop:true/')) {
+      this.edits.roundCrop = true;
+    }
+
     // Parse the image path
     let edits = this.path.match(/filters:[^)]+/g);
     if (!edits) {
@@ -255,7 +260,7 @@ class ThumborMapping {
       if (allowedPosPattern.test(yPos) || !isNaN(yPos)) {
         this.edits.overlayWith.options['top'] = yPos;
       }
-    } else if (editKey === 'round') {
+    } else if (editKey === 'roundCrop') {
         // Rounded crops, with optional coordinates
         const roundedImages = value.match(/(\d+)x(\d+)(:(\d+)x(\d+))?/);
         if (roundedImages) {
@@ -269,6 +274,8 @@ class ThumborMapping {
             if (!isNaN(top)) this.edits.roundCrop.top = top;
             if (!isNaN(r_x)) this.edits.roundCrop.rx = r_x;
             if (!isNaN(r_y)) this.edits.roundCrop.ry = r_y;
+        } else if (value === 'true' || value === '') {
+          this.edits.roundCrop = {};
         }
     } else {
       return undefined;


### PR DESCRIPTION
- unified new `roundCrop` filter 
    - "free" `/filters:roundCrop(66x66:20x30)/` 
    - "centered" `/filters:roundCrop(true)/` or `/filters:roundCrop()/`
- its recommended to use in conjunction with `/filters:format(png)/` to make the cutout transparent (transparency does not work with JPEG)
- bump sharp to latest (`0.31.1`)