### PR TITLE
chore: reduce `effort` for `avif` output

### DIFF
--- a/source/image-handler/src/image-handler.ts
+++ b/source/image-handler/src/image-handler.ts
@@ -3,15 +3,7 @@
 
 import sharp, { OverlayOptions, SharpOptions } from 'sharp';
 
-import {
-  ContentTypes,
-  ImageEdits,
-  ImageFitTypes,
-  ImageFormatTypes,
-  ImageHandlerError,
-  ImageRequestInfo,
-  StatusCodes,
-} from './lib';
+import { ContentTypes, ImageEdits, ImageFitTypes, ImageFormatTypes, ImageHandlerError, ImageRequestInfo, StatusCodes, } from './lib';
 import { S3 } from '@aws-sdk/client-s3';
 import { rgbaToThumbHash } from './lib/thumbhash';
 
@@ -76,7 +68,7 @@ export class ImageHandler {
       ImageFormatTypes.AVIF == imageRequestInfo.outputFormat ||
       (undefined === imageRequestInfo.outputFormat && imageRequestInfo.contentType === ContentTypes.AVIF)
     ) {
-      modifiedOutputImage.avif({ quality: 75, effort: 7 });
+      modifiedOutputImage.avif({ quality: 70, effort: 0 });
     }
 
     return modifiedOutputImage;


### PR DESCRIPTION
`avif` is quite compute intensive .. on my M2 MAC `effort` had the following effects:

* `effort=0` (fastest): ~ 0.5 seconds
* `effort=1` ~ 0.6 seconds
* `effort=7` (current): ~ 5.5 seconds
* `effort=9` (best): ~ 10.5 seconds